### PR TITLE
Remove named export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,8 @@ goog.require('i18n.phonenumbers.AsYouTypeFormatter');
  * Export `libphonenumber`.
  */
 
-module.exports = i18n.phonenumbers.default = i18n.phonenumbers.libphonenumber = i18n.phonenumbers;
+Object.defineProperty(exports, '__esModule', { value: true });
+
+exports.default = i18n.phonenumbers;
+
+module.exports = exports['default'];

--- a/test/exports_test.js
+++ b/test/exports_test.js
@@ -23,8 +23,6 @@ describe('Exports', function() {
       'PhoneNumberFormat',
       'PhoneNumberType',
       'PhoneNumberUtil',
-      'default',
-      'libphonenumber',
       'metadata'
     ]);
   });


### PR DESCRIPTION
Keep the default export only. There's no point in export being named and non-named.