### PR TITLE
Load resources to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <title>google-libphonenumber</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js"></script>
   <script src="https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js"></script>
 
@@ -38,7 +38,7 @@
       </ul>
     </div>
     <div class="right">
-      <iframe src="http://ghbtns.com/github-btn.html?user=seegno&amp;repo=google-libphonenumber&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=seegno&amp;repo=google-libphonenumber&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 


### PR DESCRIPTION
This solves mixed content warnings. Especially since Chrome now blocks HTTP resources loaded on an HTTPS page.